### PR TITLE
Add machine-readable JSON report output for dashboard consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A fast, Docker-based GitHub Action for validating test coverage from XML files a
 - ✅ **Configurable thresholds** - Set minimum coverage percentages
 - ✅ **Clear output** - Colored logs and detailed error messages
 - ✅ **GitHub Actions integration** - Outputs for use in other steps
+- ✅ **Machine-readable JSON report** - A structured summary for dashboards and other tooling
 
 ## Supported Coverage Formats
 
@@ -83,6 +84,7 @@ This action follows semantic versioning with convenience tags:
 | `minimum-coverage` | Minimum coverage percentage required | ❌ | 85 |
 | `coverage-type` | XML format type (`clover`, `cobertura`, `jacoco`) | ❌ | `cobertura` |
 | `working-directory` | Working directory for the coverage file | ❌ | `.` |
+| `json-report-file` | Path to write a machine-readable JSON report (relative to `working-directory`) | ❌ | - |
 
 ## Outputs
 
@@ -90,6 +92,48 @@ This action follows semantic versioning with convenience tags:
 |--------|-------------|
 | `coverage-percentage` | The actual coverage percentage found |
 | `status` | `pass` or `fail` status of validation |
+| `report-json` | A compact JSON string summarizing the coverage report |
+| `report-file` | Path to the JSON report file (only set when `json-report-file` is provided) |
+
+## Machine-Readable Report
+
+For dashboards or other tooling that consume coverage results, the action can emit a
+structured JSON report, either as the `report-json` output or as a file:
+
+```yaml
+- name: Validate Coverage
+  id: coverage
+  uses: vln-devsecops/actions-validate-coverage@v1
+  with:
+    coverage-file: 'coverage/clover.xml'
+    minimum-coverage: '80'
+    json-report-file: 'coverage-report.json'
+
+- name: Upload coverage report
+  if: always()
+  uses: actions/upload-artifact@v4
+  with:
+    name: coverage-report
+    path: coverage-report.json
+```
+
+The report has the following shape:
+
+```json
+{
+  "coverageFile": "coverage/clover.xml",
+  "coverageType": "clover",
+  "coveragePercentage": 85,
+  "minimumCoverage": 80,
+  "status": "pass",
+  "covered": 85,
+  "total": 100,
+  "timestamp": "2026-07-11T16:10:40Z"
+}
+```
+
+`covered` and `total` are `null` when the coverage format doesn't expose those counts
+(for example, a Cobertura file without `lines-covered`/`lines-valid` attributes).
 
 ## Examples
 

--- a/action.yml
+++ b/action.yml
@@ -22,12 +22,20 @@ inputs:
     description: 'Working directory where the coverage file is located'
     required: false
     default: '.'
+  json-report-file:
+    description: 'Path to write a machine-readable JSON coverage report, for dashboard consumption (relative to working-directory)'
+    required: false
+    default: ''
 
 outputs:
   coverage-percentage:
     description: 'The actual coverage percentage found'
   status:
     description: 'Pass or fail status of the validation'
+  report-json:
+    description: 'A compact JSON string summarizing the coverage report, for machine consumption'
+  report-file:
+    description: 'Path to the JSON report file (only set when json-report-file is provided)'
 
 runs:
   using: 'docker'
@@ -40,3 +48,4 @@ runs:
     - ${{ inputs.minimum-coverage }}
     - ${{ inputs.coverage-type }}
     - ${{ inputs.working-directory }}
+    - ${{ inputs.json-report-file }}

--- a/tests/validate-coverage.bats
+++ b/tests/validate-coverage.bats
@@ -23,6 +23,12 @@ assert_output_contains() {
     assert_output_contains "Coverage validation passed!"
     grep -Fx "coverage-percentage=85" "$OUTPUT_FILE"
     grep -Fx "status=pass" "$OUTPUT_FILE"
+
+    report_json="$(grep "^report-json=" "$OUTPUT_FILE" | cut -d= -f2-)"
+    [ "$(echo "$report_json" | jq -r '.coveragePercentage')" = "85" ]
+    [ "$(echo "$report_json" | jq -r '.status')" = "pass" ]
+    [ "$(echo "$report_json" | jq -r '.covered')" = "85" ]
+    [ "$(echo "$report_json" | jq -r '.total')" = "100" ]
 }
 
 @test "fails when coverage is below the minimum and writes fail status" {
@@ -35,6 +41,34 @@ assert_output_contains() {
     assert_output_contains "Actual coverage (85%) is below minimum required (90%)"
     grep -Fx "coverage-percentage=85" "$OUTPUT_FILE"
     grep -Fx "status=fail" "$OUTPUT_FILE"
+
+    report_json="$(grep "^report-json=" "$OUTPUT_FILE" | cut -d= -f2-)"
+    [ "$(echo "$report_json" | jq -r '.status')" = "fail" ]
+}
+
+@test "writes a JSON report file when json-report-file is provided" {
+    export GITHUB_OUTPUT="$OUTPUT_FILE"
+    report_file="$BATS_TEST_TMPDIR/coverage-report.json"
+
+    run "$SCRIPT" "$REPO_ROOT/examples/clover.xml" 80 clover . "$report_file"
+
+    [ "$status" -eq 0 ]
+    [ -f "$report_file" ]
+    [ "$(jq -r '.coveragePercentage' "$report_file")" = "85" ]
+    [ "$(jq -r '.status' "$report_file")" = "pass" ]
+    grep -Fx "report-file=${report_file}" "$OUTPUT_FILE"
+}
+
+@test "reports null covered/total for cobertura files without line counts" {
+    export GITHUB_OUTPUT="$OUTPUT_FILE"
+
+    run "$SCRIPT" "$REPO_ROOT/examples/cobertura.xml" 80 cobertura
+
+    [ "$status" -eq 0 ]
+
+    report_json="$(grep "^report-json=" "$OUTPUT_FILE" | cut -d= -f2-)"
+    [ "$(echo "$report_json" | jq -r '.covered')" = "null" ]
+    [ "$(echo "$report_json" | jq -r '.total')" = "null" ]
 }
 
 @test "auto-detects cobertura when clover is requested by default" {

--- a/tests/validate-coverage.bats
+++ b/tests/validate-coverage.bats
@@ -59,6 +59,20 @@ assert_output_contains() {
     grep -Fx "report-file=${report_file}" "$OUTPUT_FILE"
 }
 
+@test "resolves a relative json-report-file against the workspace root, creating missing directories" {
+    export GITHUB_OUTPUT="$OUTPUT_FILE"
+    mkdir -p "$BATS_TEST_TMPDIR/project/coverage"
+    cp "$REPO_ROOT/examples/clover.xml" "$BATS_TEST_TMPDIR/project/coverage/clover.xml"
+
+    run "$SCRIPT" "coverage/clover.xml" 80 clover "$BATS_TEST_TMPDIR/project" "reports/coverage-report.json"
+
+    [ "$status" -eq 0 ]
+    expected_file="$BATS_TEST_TMPDIR/project/reports/coverage-report.json"
+    [ -f "$expected_file" ]
+    [ "$(jq -r '.status' "$expected_file")" = "pass" ]
+    grep -Fx "report-file=${expected_file}" "$OUTPUT_FILE"
+}
+
 @test "reports null covered/total for cobertura files without line counts" {
     export GITHUB_OUTPUT="$OUTPUT_FILE"
 

--- a/validate-coverage.sh
+++ b/validate-coverage.sh
@@ -6,6 +6,7 @@ COVERAGE_FILE="$1"
 MINIMUM_COVERAGE="$2"
 COVERAGE_TYPE="${3:-clover}"
 WORKING_DIRECTORY="${4:-.}"
+JSON_REPORT_FILE="${5:-}"
 
 # Colors for output
 RED='\033[0;31m'
@@ -33,18 +34,20 @@ error() {
 
 # Function to show usage
 show_usage() {
-    echo "Usage: $0 <coverage-file> <minimum-percentage> [coverage-type] [working-directory]"
+    echo "Usage: $0 <coverage-file> <minimum-percentage> [coverage-type] [working-directory] [json-report-file]"
     echo ""
     echo "Parameters:"
     echo "  coverage-file       Path to the coverage file"
     echo "  minimum-percentage  Minimum coverage percentage (0-100)"
     echo "  coverage-type       Type of coverage file (clover, cobertura, jacoco) - defaults to 'clover'"
     echo "  working-directory   Working directory - defaults to current directory"
+    echo "  json-report-file    Path to write a machine-readable JSON report - optional"
     echo ""
     echo "Examples:"
     echo "  $0 coverage/clover.xml 80"
     echo "  $0 coverage/cobertura.xml 75 cobertura"
     echo "  $0 coverage/jacoco.xml 90 jacoco /path/to/project"
+    echo "  $0 coverage/clover.xml 80 clover . coverage-report.json"
 }
 
 detect_coverage_type() {
@@ -151,14 +154,18 @@ case "$COVERAGE_TYPE" in
         
         # Extract line-rate from Cobertura XML (already a percentage)
         LINE_RATE=$(xmllint --xpath "string(/coverage/@line-rate)" "$COVERAGE_FILE" 2>/dev/null || echo "0")
-        
+
         if [ "$LINE_RATE" = "0" ] || [ -z "$LINE_RATE" ]; then
             error "No line rate found in coverage file or invalid Cobertura format"
             exit 1
         fi
-        
+
         # Convert decimal to percentage
         COVERAGE=$(echo "$LINE_RATE * 100" | bc | cut -d. -f1)
+
+        # Extract covered/total line counts if present, for the JSON report
+        COVERED=$(xmllint --xpath "string(/coverage/@lines-covered)" "$COVERAGE_FILE" 2>/dev/null || echo "")
+        TOTAL=$(xmllint --xpath "string(/coverage/@lines-valid)" "$COVERAGE_FILE" 2>/dev/null || echo "")
         ;;
         
     "jacoco")
@@ -203,23 +210,61 @@ fi
 
 log "Actual coverage: ${COVERAGE}%"
 
+# Determine pass/fail status
+if [ "$COVERAGE" -lt "$MINIMUM_COVERAGE" ]; then
+    STATUS="fail"
+else
+    STATUS="pass"
+fi
+
+# Build a machine-readable JSON report for dashboard consumption
+if ! command -v jq &> /dev/null; then
+    error "jq is required but not installed"
+    exit 1
+fi
+
+REPORT_JSON=$(jq -nc \
+    --arg coverageFile "$COVERAGE_FILE" \
+    --arg coverageType "$COVERAGE_TYPE" \
+    --argjson coveragePercentage "$COVERAGE" \
+    --argjson minimumCoverage "$MINIMUM_COVERAGE" \
+    --arg status "$STATUS" \
+    --arg covered "${COVERED:-}" \
+    --arg total "${TOTAL:-}" \
+    --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{
+        coverageFile: $coverageFile,
+        coverageType: $coverageType,
+        coveragePercentage: $coveragePercentage,
+        minimumCoverage: $minimumCoverage,
+        status: $status,
+        covered: (if $covered == "" then null else ($covered | tonumber) end),
+        total: (if $total == "" then null else ($total | tonumber) end),
+        timestamp: $timestamp
+    }')
+
 # Set outputs for GitHub Actions (if running in GitHub Actions)
 if [ -n "$GITHUB_OUTPUT" ]; then
     echo "coverage-percentage=${COVERAGE}" >> "$GITHUB_OUTPUT"
+    echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
+    echo "report-json=${REPORT_JSON}" >> "$GITHUB_OUTPUT"
+fi
+
+# Write the JSON report to file, if requested
+if [ -n "$JSON_REPORT_FILE" ]; then
+    echo "$REPORT_JSON" | jq '.' > "$JSON_REPORT_FILE"
+    log "Wrote JSON report to: $JSON_REPORT_FILE"
+    if [ -n "$GITHUB_OUTPUT" ]; then
+        echo "report-file=${JSON_REPORT_FILE}" >> "$GITHUB_OUTPUT"
+    fi
 fi
 
 # Compare with minimum
-if [ "$COVERAGE" -lt "$MINIMUM_COVERAGE" ]; then
-    if [ -n "$GITHUB_OUTPUT" ]; then
-        echo "status=fail" >> "$GITHUB_OUTPUT"
-    fi
+if [ "$STATUS" = "fail" ]; then
     error "Coverage validation failed!"
     error "Actual coverage (${COVERAGE}%) is below minimum required (${MINIMUM_COVERAGE}%)"
     exit 1
 else
-    if [ -n "$GITHUB_OUTPUT" ]; then
-        echo "status=pass" >> "$GITHUB_OUTPUT"
-    fi
     success "Coverage validation passed!"
     success "Actual coverage (${COVERAGE}%) meets minimum requirement (${MINIMUM_COVERAGE}%)"
 fi

--- a/validate-coverage.sh
+++ b/validate-coverage.sh
@@ -243,20 +243,22 @@ REPORT_JSON=$(jq -nc \
         timestamp: $timestamp
     }')
 
-# Set outputs for GitHub Actions (if running in GitHub Actions)
-if [ -n "$GITHUB_OUTPUT" ]; then
-    echo "coverage-percentage=${COVERAGE}" >> "$GITHUB_OUTPUT"
-    echo "status=${STATUS}" >> "$GITHUB_OUTPUT"
-    echo "report-json=${REPORT_JSON}" >> "$GITHUB_OUTPUT"
-fi
-
 # Write the JSON report to file, if requested
 if [ -n "$JSON_REPORT_FILE" ]; then
     echo "$REPORT_JSON" | jq '.' > "$JSON_REPORT_FILE"
     log "Wrote JSON report to: $JSON_REPORT_FILE"
-    if [ -n "$GITHUB_OUTPUT" ]; then
-        echo "report-file=${JSON_REPORT_FILE}" >> "$GITHUB_OUTPUT"
-    fi
+fi
+
+# Set outputs for GitHub Actions (if running in GitHub Actions)
+if [ -n "$GITHUB_OUTPUT" ]; then
+    {
+        echo "coverage-percentage=${COVERAGE}"
+        echo "status=${STATUS}"
+        echo "report-json=${REPORT_JSON}"
+        if [ -n "$JSON_REPORT_FILE" ]; then
+            echo "report-file=${JSON_REPORT_FILE}"
+        fi
+    } >> "$GITHUB_OUTPUT"
 fi
 
 # Compare with minimum

--- a/validate-coverage.sh
+++ b/validate-coverage.sh
@@ -243,9 +243,13 @@ REPORT_JSON=$(jq -nc \
         timestamp: $timestamp
     }')
 
-# Write the JSON report to file, if requested
+# Write the JSON report to file, if requested. Resolve to an absolute path
+# since downstream steps (e.g. actions/upload-artifact) resolve relative
+# paths against the workspace root, not this script's working directory.
 if [ -n "$JSON_REPORT_FILE" ]; then
+    mkdir -p "$(dirname "$JSON_REPORT_FILE")"
     echo "$REPORT_JSON" | jq '.' > "$JSON_REPORT_FILE"
+    JSON_REPORT_FILE="$(cd "$(dirname "$JSON_REPORT_FILE")" && pwd)/$(basename "$JSON_REPORT_FILE")"
     log "Wrote JSON report to: $JSON_REPORT_FILE"
 fi
 


### PR DESCRIPTION
## Summary
- Add a `report-json` GitHub Actions output containing a compact JSON summary of the coverage validation (`coverageFile`, `coverageType`, `coveragePercentage`, `minimumCoverage`, `status`, `covered`, `total`, `timestamp`)
- Add an optional `json-report-file` input; when set, the same report is also written to a file (e.g. for upload as a workflow artifact) with a matching `report-file` output
- Extract `covered`/`total` line counts for Cobertura reports when the `lines-covered`/`lines-valid` attributes are present (they were previously only available for Clover/JaCoCo); falls back to `null` when unavailable
- Document the new output in the README with a dashboard-oriented usage example

## Test plan
- [x] `bats tests/validate-coverage.bats` — all 11 tests pass, including 3 new tests covering `report-json` content, writing `json-report-file` to disk, and the Cobertura `null` covered/total case
- [x] Manually ran the script against clover/cobertura/jacoco examples (pass and fail thresholds) and verified `GITHUB_OUTPUT` and the written JSON report file
- [x] Verified `json-report-file` paths resolve relative to `working-directory`, consistent with `coverage-file`


---
_Generated by [Claude Code](https://claude.ai/code/session_01W6GVjBP39GFJJ4NbQhaDMF)_