### PR TITLE
feat: add opt-in coverage reporting (commit status + portable JSON artifact)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,32 @@ This action follows semantic versioning with convenience tags:
       })
 ```
 
+### Reporting to dashboards
+
+Set `github-token` to have the action publish a [commit status](https://docs.github.com/en/rest/commits/statuses)
+with the coverage result. This is opt-in and off by default — without it, the action behaves exactly as before.
+
+```yaml
+- name: Validate Coverage
+  id: coverage
+  uses: vln-devsecops/actions-validate-coverage@v1
+  with:
+    coverage-file: 'coverage/cobertura.xml'
+    minimum-coverage: '80'
+    github-token: ${{ github.token }}
+```
+
+The status is posted using the workflow's own `GITHUB_TOKEN` (the default `statuses: write`
+permission is enough — no PAT or cross-repo secret needed), with a `context` starting with
+`coverage` and a `description` of the form `Coverage: <percentage>% (min <minimum>%)`.
+
+This is what feeds the `vln-devsecops/operations` org dashboard's coverage column. The dashboard
+reads the combined commit status of each monitored repo's **default branch**, so the status only
+shows up there if it's posted from a run against the default branch's latest commit (e.g. a `push`
+trigger on `main`) — a status posted from a pull-request run against a feature-branch commit won't
+be picked up. If you want the dashboard to reflect your coverage, make sure `github-token` is set
+on the workflow run that triggers on your default branch.
+
 ## Inputs
 
 | Input | Description | Required | Default |
@@ -83,6 +109,8 @@ This action follows semantic versioning with convenience tags:
 | `minimum-coverage` | Minimum coverage percentage required | ❌ | 85 |
 | `coverage-type` | XML format type (`clover`, `cobertura`, `jacoco`) | ❌ | `cobertura` |
 | `working-directory` | Working directory for the coverage file | ❌ | `.` |
+| `github-token` | Token used to publish a commit status with the coverage result (e.g. `${{ github.token }}`). Omit to skip status publishing entirely — the action behaves exactly as before | ❌ | - |
+| `status-context` | Commit status context to publish under. Must start with `coverage` to be picked up by the org dashboard | ❌ | `coverage/validate-coverage` |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A fast, Docker-based GitHub Action for validating test coverage from XML files a
 - ✅ **Configurable thresholds** - Set minimum coverage percentages
 - ✅ **Clear output** - Colored logs and detailed error messages
 - ✅ **GitHub Actions integration** - Outputs for use in other steps
+- ✅ **Portable machine-readable report** - A JSON summary any org's dashboard can consume as a workflow artifact
 
 ## Supported Coverage Formats
 
@@ -77,8 +78,13 @@ This action follows semantic versioning with convenience tags:
 
 ### Reporting to dashboards
 
+There are two independent, opt-in ways to feed a coverage result to a dashboard. Use either or
+both — neither changes the action's default behavior, and enabling one does not require the other.
+
+#### Commit status (for the `vln-devsecops` org dashboard)
+
 Set `github-token` to have the action publish a [commit status](https://docs.github.com/en/rest/commits/statuses)
-with the coverage result. This is opt-in and off by default — without it, the action behaves exactly as before.
+with the coverage result.
 
 ```yaml
 - name: Validate Coverage
@@ -94,12 +100,61 @@ The status is posted using the workflow's own `GITHUB_TOKEN` (the default `statu
 permission is enough — no PAT or cross-repo secret needed), with a `context` starting with
 `coverage` and a `description` of the form `Coverage: <percentage>% (min <minimum>%)`.
 
-This is what feeds the `vln-devsecops/operations` org dashboard's coverage column. The dashboard
-reads the combined commit status of each monitored repo's **default branch**, so the status only
-shows up there if it's posted from a run against the default branch's latest commit (e.g. a `push`
-trigger on `main`) — a status posted from a pull-request run against a feature-branch commit won't
-be picked up. If you want the dashboard to reflect your coverage, make sure `github-token` is set
-on the workflow run that triggers on your default branch.
+This is what feeds the `vln-devsecops/operations` org dashboard's coverage column specifically.
+That dashboard reads the combined commit status of each monitored repo's **default branch**, so the
+status only shows up there if it's posted from a run against the default branch's latest commit
+(e.g. a `push` trigger on `main`) — a status posted from a pull-request run against a feature-branch
+commit won't be picked up. If you want that dashboard to reflect your coverage, make sure
+`github-token` is set on the workflow run that triggers on your default branch.
+
+This mechanism isn't specific to any one repo or org beyond needing that dashboard's consumer code
+to be pointed at it — each caller posts to its own repo with its own token. If your org's tooling
+can't read commit statuses, use the JSON report below instead.
+
+#### JSON report (portable — any org, any dashboard)
+
+The action always produces a `report-json` output: a compact JSON summary of the coverage result,
+independent of the commit-status feature above and requiring no token. Set `json-report-file` to
+additionally have it written to disk, so it can be uploaded as a workflow artifact for a dashboard
+(in any org) to fetch and parse later:
+
+```yaml
+- name: Validate Coverage
+  id: coverage
+  uses: vln-devsecops/actions-validate-coverage@v1
+  with:
+    coverage-file: 'coverage/clover.xml'
+    minimum-coverage: '80'
+    json-report-file: 'coverage-report.json'
+
+- name: Upload coverage report
+  if: always()
+  uses: actions/upload-artifact@v4
+  with:
+    name: coverage-report
+    path: coverage-report.json
+```
+
+The report has the following shape:
+
+```json
+{
+  "coverageFile": "coverage/clover.xml",
+  "coverageType": "clover",
+  "coveragePercentage": 85,
+  "minimumCoverage": 80,
+  "status": "pass",
+  "covered": 85,
+  "total": 100,
+  "timestamp": "2026-07-11T16:10:40Z"
+}
+```
+
+`covered` and `total` are `null` when the coverage format doesn't expose those counts (for example,
+a Cobertura file without `lines-covered`/`lines-valid` attributes). Report generation is
+best-effort: if `jq` is unavailable or fails to build the report, the action logs a warning and
+still exits with the normal pass/fail status — a broken report never fails an otherwise-successful
+validation run.
 
 ## Inputs
 
@@ -111,6 +166,7 @@ on the workflow run that triggers on your default branch.
 | `working-directory` | Working directory for the coverage file | ❌ | `.` |
 | `github-token` | Token used to publish a commit status with the coverage result (e.g. `${{ github.token }}`). Omit to skip status publishing entirely — the action behaves exactly as before | ❌ | - |
 | `status-context` | Commit status context to publish under. Must start with `coverage` to be picked up by the org dashboard | ❌ | `coverage/validate-coverage` |
+| `json-report-file` | Path to write a machine-readable JSON coverage report (relative to `working-directory`), for dashboards in other orgs that consume a workflow artifact instead of a commit status. Omit to skip file generation — the `report-json` output is still produced | ❌ | - |
 
 ## Outputs
 
@@ -118,6 +174,8 @@ on the workflow run that triggers on your default branch.
 |--------|-------------|
 | `coverage-percentage` | The actual coverage percentage found |
 | `status` | `pass` or `fail` status of validation |
+| `report-json` | A compact JSON string summarizing the coverage report (see shape above) |
+| `report-file` | Absolute path to the written JSON report file (only set when `json-report-file` is provided and the write succeeds) |
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ This action follows semantic versioning with convenience tags:
 There are two independent, opt-in ways to feed a coverage result to a dashboard. Use either or
 both — neither changes the action's default behavior, and enabling one does not require the other.
 
-#### Commit status (for the `vln-devsecops` org dashboard)
+#### Commit status (GitHub-native, any consumer)
 
 Set `github-token` to have the action publish a [commit status](https://docs.github.com/en/rest/commits/statuses)
-with the coverage result.
+with the coverage result, readable by any dashboard or tool that consumes GitHub's commit-status API.
 
 ```yaml
 - name: Validate Coverage
@@ -100,16 +100,16 @@ The status is posted using the workflow's own `GITHUB_TOKEN` (the default `statu
 permission is enough — no PAT or cross-repo secret needed), with a `context` starting with
 `coverage` and a `description` of the form `Coverage: <percentage>% (min <minimum>%)`.
 
-This is what feeds the `vln-devsecops/operations` org dashboard's coverage column specifically.
-That dashboard reads the combined commit status of each monitored repo's **default branch**, so the
-status only shows up there if it's posted from a run against the default branch's latest commit
-(e.g. a `push` trigger on `main`) — a status posted from a pull-request run against a feature-branch
-commit won't be picked up. If you want that dashboard to reflect your coverage, make sure
-`github-token` is set on the workflow run that triggers on your default branch.
+One example consumer is the `vln-devsecops/operations` org dashboard, which reads the combined
+commit status of each monitored repo's **default branch** and looks for a `context` starting with
+`coverage`. Most commit-status consumers work the same way — the status only shows up if it's
+posted from a run against the default branch's latest commit (e.g. a `push` trigger on `main`), not
+from a pull-request run against a feature-branch commit. If your dashboard reads a repo's default
+branch status, make sure `github-token` is set on the workflow run that triggers there.
 
-This mechanism isn't specific to any one repo or org beyond needing that dashboard's consumer code
-to be pointed at it — each caller posts to its own repo with its own token. If your org's tooling
-can't read commit statuses, use the JSON report below instead.
+Each caller posts its own commit status to its own repo with its own token, so this works the same
+way for any repo or org — it isn't specific to `vln-devsecops`. If your dashboard doesn't (or can't)
+read commit statuses, use the JSON report below instead.
 
 #### JSON report (portable — any org, any dashboard)
 
@@ -132,7 +132,7 @@ additionally have it written to disk, so it can be uploaded as a workflow artifa
   uses: actions/upload-artifact@v4
   with:
     name: coverage-report
-    path: coverage-report.json
+    path: ${{ steps.coverage.outputs.report-file }}
 ```
 
 The report has the following shape:
@@ -165,8 +165,8 @@ validation run.
 | `coverage-type` | XML format type (`clover`, `cobertura`, `jacoco`) | ❌ | `cobertura` |
 | `working-directory` | Working directory for the coverage file | ❌ | `.` |
 | `github-token` | Token used to publish a commit status with the coverage result (e.g. `${{ github.token }}`). Omit to skip status publishing entirely — the action behaves exactly as before | ❌ | - |
-| `status-context` | Commit status context to publish under. Must start with `coverage` to be picked up by the org dashboard | ❌ | `coverage/validate-coverage` |
-| `json-report-file` | Path to write a machine-readable JSON coverage report (relative to `working-directory`), for dashboards in other orgs that consume a workflow artifact instead of a commit status. Omit to skip file generation — the `report-json` output is still produced | ❌ | - |
+| `status-context` | Commit status context to publish under. Use a prefix a consumer filters on — `coverage` (the default) is what the `vln-devsecops/operations` dashboard looks for | ❌ | `coverage/validate-coverage` |
+| `json-report-file` | Path to write a machine-readable JSON coverage report (relative to `working-directory`), for dashboards that consume a workflow artifact instead of a commit status. Omit to skip file generation — the `report-json` output is still produced | ❌ | - |
 
 ## Outputs
 
@@ -175,7 +175,7 @@ validation run.
 | `coverage-percentage` | The actual coverage percentage found |
 | `status` | `pass` or `fail` status of validation |
 | `report-json` | A compact JSON string summarizing the coverage report (see shape above) |
-| `report-file` | Absolute path to the written JSON report file (only set when `json-report-file` is provided and the write succeeds) |
+| `report-file` | Path to the written JSON report file, relative to `$GITHUB_WORKSPACE` when possible so it's directly usable by later steps like `actions/upload-artifact` (falls back to an absolute container path otherwise). Only set when `json-report-file` is provided and the write succeeds |
 
 ## Examples
 

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ outputs:
   report-json:
     description: 'A compact JSON string summarizing the coverage report (coverageFile, coverageType, coveragePercentage, minimumCoverage, status, covered, total, timestamp)'
   report-file:
-    description: 'Absolute path to the written JSON report file (only set when json-report-file is provided and the write succeeds)'
+    description: 'Path to the written JSON report file, relative to $GITHUB_WORKSPACE when the report lives under it (falls back to an absolute container path otherwise) so it can be used directly by later steps like actions/upload-artifact. Only set when json-report-file is provided and the write succeeds'
 
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -29,12 +29,20 @@ inputs:
     description: 'Commit status context to publish under. Must start with "coverage" to be picked up by the org dashboard.'
     required: false
     default: 'coverage/validate-coverage'
+  json-report-file:
+    description: 'Path to write a machine-readable JSON coverage report (relative to working-directory), for dashboards in other orgs that consume a workflow artifact instead of a commit status. Omit to skip report-file generation — the report-json output is still produced.'
+    required: false
+    default: ''
 
 outputs:
   coverage-percentage:
     description: 'The actual coverage percentage found'
   status:
     description: 'Pass or fail status of the validation'
+  report-json:
+    description: 'A compact JSON string summarizing the coverage report (coverageFile, coverageType, coveragePercentage, minimumCoverage, status, covered, total, timestamp)'
+  report-file:
+    description: 'Absolute path to the written JSON report file (only set when json-report-file is provided and the write succeeds)'
 
 runs:
   using: 'docker'
@@ -47,6 +55,7 @@ runs:
     - ${{ inputs.minimum-coverage }}
     - ${{ inputs.coverage-type }}
     - ${{ inputs.working-directory }}
+    - ${{ inputs.json-report-file }}
   env:
     STATUS_TOKEN: ${{ inputs.github-token }}
     STATUS_CONTEXT: ${{ inputs.status-context }}

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,13 @@ inputs:
     description: 'Working directory where the coverage file is located'
     required: false
     default: '.'
+  github-token:
+    description: 'Token used to publish a commit status with the coverage result (e.g. ${{ github.token }}). Omit to skip status publishing entirely — the action behaves exactly as before.'
+    required: false
+  status-context:
+    description: 'Commit status context to publish under. Must start with "coverage" to be picked up by the org dashboard.'
+    required: false
+    default: 'coverage/validate-coverage'
 
 outputs:
   coverage-percentage:
@@ -40,3 +47,6 @@ runs:
     - ${{ inputs.minimum-coverage }}
     - ${{ inputs.coverage-type }}
     - ${{ inputs.working-directory }}
+  env:
+    STATUS_TOKEN: ${{ inputs.github-token }}
+    STATUS_CONTEXT: ${{ inputs.status-context }}

--- a/tests/validate-coverage.bats
+++ b/tests/validate-coverage.bats
@@ -8,6 +8,7 @@ setup() {
     unset GITHUB_OUTPUT
     unset STATUS_TOKEN
     unset STATUS_CONTEXT
+    unset GITHUB_WORKSPACE
     export GITHUB_SERVER_URL="https://github.com"
     export GITHUB_REPOSITORY="acme/widgets"
     export GITHUB_SHA="deadbeef"
@@ -250,6 +251,42 @@ EOF
     [ -f "$expected_file" ]
     [ "$(jq -r '.status' "$expected_file")" = "pass" ]
     grep -Fx "report-file=${expected_file}" "$OUTPUT_FILE"
+}
+
+@test "emits a workspace-relative report-file when GITHUB_WORKSPACE is set" {
+    export GITHUB_OUTPUT="$OUTPUT_FILE"
+    export GITHUB_WORKSPACE="$BATS_TEST_TMPDIR"
+    report_file="$BATS_TEST_TMPDIR/coverage-report.json"
+
+    run "$SCRIPT" "$REPO_ROOT/examples/clover.xml" 80 clover . "$report_file"
+
+    [ "$status" -eq 0 ]
+    [ -f "$report_file" ]
+    grep -Fx "report-file=coverage-report.json" "$OUTPUT_FILE"
+}
+
+@test "emits a workspace-relative report-file for nested paths under GITHUB_WORKSPACE" {
+    export GITHUB_OUTPUT="$OUTPUT_FILE"
+    mkdir -p "$BATS_TEST_TMPDIR/project/coverage"
+    cp "$REPO_ROOT/examples/clover.xml" "$BATS_TEST_TMPDIR/project/coverage/clover.xml"
+    export GITHUB_WORKSPACE="$BATS_TEST_TMPDIR/project"
+
+    run "$SCRIPT" "coverage/clover.xml" 80 clover "$BATS_TEST_TMPDIR/project" "reports/coverage-report.json"
+
+    [ "$status" -eq 0 ]
+    [ -f "$BATS_TEST_TMPDIR/project/reports/coverage-report.json" ]
+    grep -Fx "report-file=reports/coverage-report.json" "$OUTPUT_FILE"
+}
+
+@test "falls back to an absolute report-file path when it's outside GITHUB_WORKSPACE" {
+    export GITHUB_OUTPUT="$OUTPUT_FILE"
+    export GITHUB_WORKSPACE="$BATS_TEST_TMPDIR/unrelated-workspace"
+    report_file="$BATS_TEST_TMPDIR/coverage-report.json"
+
+    run "$SCRIPT" "$REPO_ROOT/examples/clover.xml" 80 clover . "$report_file"
+
+    [ "$status" -eq 0 ]
+    grep -Fx "report-file=${report_file}" "$OUTPUT_FILE"
 }
 
 @test "does not fail the script when building the JSON report fails" {

--- a/tests/validate-coverage.bats
+++ b/tests/validate-coverage.bats
@@ -37,6 +37,19 @@ EOF
     PATH="$bin_dir:$PATH"
 }
 
+# Installs a fake `jq` ahead of the real one on PATH that always fails, to
+# verify a broken payload build doesn't abort the script under `set -e`.
+setup_failing_jq() {
+    local bin_dir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$bin_dir"
+    cat > "$bin_dir/jq" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+    chmod +x "$bin_dir/jq"
+    PATH="$bin_dir:$PATH"
+}
+
 @test "passes clover coverage and writes action outputs" {
     export GITHUB_OUTPUT="$OUTPUT_FILE"
 
@@ -161,5 +174,16 @@ EOF
 
     [ "$status" -eq 0 ]
     assert_output_contains "::warning::failed to publish coverage commit status"
+    assert_output_contains "Coverage validation passed!"
+}
+
+@test "does not fail the script when building the status payload fails" {
+    setup_failing_jq
+    export STATUS_TOKEN="test-token"
+
+    run "$SCRIPT" "$REPO_ROOT/examples/clover.xml" 80 clover
+
+    [ "$status" -eq 0 ]
+    assert_output_contains "::warning::failed to build coverage commit status payload"
     assert_output_contains "Coverage validation passed!"
 }

--- a/tests/validate-coverage.bats
+++ b/tests/validate-coverage.bats
@@ -6,11 +6,35 @@ setup() {
     OUTPUT_FILE="$BATS_TEST_TMPDIR/github-output.txt"
     : > "$OUTPUT_FILE"
     unset GITHUB_OUTPUT
+    unset STATUS_TOKEN
+    unset STATUS_CONTEXT
+    export GITHUB_SERVER_URL="https://github.com"
+    export GITHUB_REPOSITORY="acme/widgets"
+    export GITHUB_SHA="deadbeef"
+    export GITHUB_RUN_ID="123"
+    export GITHUB_API_URL="https://api.github.com"
 }
 
 assert_output_contains() {
     local expected="$1"
     [[ "$output" == *"$expected"* ]]
+}
+
+# Installs a fake `curl` ahead of the real one on PATH that records the
+# arguments it was called with to $CURL_LOG and exits with $exit_code.
+setup_fake_curl() {
+    local exit_code="${1:-0}"
+    CURL_LOG="$BATS_TEST_TMPDIR/curl-calls.log"
+    : > "$CURL_LOG"
+    local bin_dir="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$bin_dir"
+    cat > "$bin_dir/curl" <<EOF
+#!/bin/bash
+echo "\$@" >> "$CURL_LOG"
+exit ${exit_code}
+EOF
+    chmod +x "$bin_dir/curl"
+    PATH="$bin_dir:$PATH"
 }
 
 @test "passes clover coverage and writes action outputs" {
@@ -90,4 +114,52 @@ assert_output_contains() {
 
     [ "$status" -eq 1 ]
     assert_output_contains "No line rate found in coverage file or invalid Cobertura format"
+}
+
+@test "does not call curl when STATUS_TOKEN is unset" {
+    setup_fake_curl 0
+    unset STATUS_TOKEN
+
+    run "$SCRIPT" "$REPO_ROOT/examples/clover.xml" 80 clover
+
+    [ "$status" -eq 0 ]
+    [ ! -s "$CURL_LOG" ]
+}
+
+@test "publishes a success commit status when coverage passes and STATUS_TOKEN is set" {
+    setup_fake_curl 0
+    export STATUS_TOKEN="test-token"
+    export STATUS_CONTEXT="coverage/validate-coverage"
+
+    run "$SCRIPT" "$REPO_ROOT/examples/clover.xml" 80 clover
+
+    [ "$status" -eq 0 ]
+    [ -s "$CURL_LOG" ]
+    grep -q "api.github.com/repos/acme/widgets/statuses/deadbeef" "$CURL_LOG"
+    grep -q '"state":"success"' "$CURL_LOG"
+    grep -q '"context":"coverage/validate-coverage"' "$CURL_LOG"
+    grep -q '"description":"Coverage: 85% (min 80%)"' "$CURL_LOG"
+}
+
+@test "publishes a failure commit status when coverage fails and STATUS_TOKEN is set" {
+    setup_fake_curl 0
+    export STATUS_TOKEN="test-token"
+
+    run "$SCRIPT" "$REPO_ROOT/examples/clover.xml" 90 clover
+
+    [ "$status" -eq 1 ]
+    [ -s "$CURL_LOG" ]
+    grep -q '"state":"failure"' "$CURL_LOG"
+    grep -q '"description":"Coverage: 85% (min 90%)"' "$CURL_LOG"
+}
+
+@test "does not fail the script when the commit status POST fails" {
+    setup_fake_curl 1
+    export STATUS_TOKEN="test-token"
+
+    run "$SCRIPT" "$REPO_ROOT/examples/clover.xml" 80 clover
+
+    [ "$status" -eq 0 ]
+    assert_output_contains "::warning::failed to publish coverage commit status"
+    assert_output_contains "Coverage validation passed!"
 }

--- a/tests/validate-coverage.bats
+++ b/tests/validate-coverage.bats
@@ -187,3 +187,95 @@ EOF
     assert_output_contains "::warning::failed to build coverage commit status payload"
     assert_output_contains "Coverage validation passed!"
 }
+
+@test "always emits a report-json output alongside the existing outputs" {
+    export GITHUB_OUTPUT="$OUTPUT_FILE"
+
+    run "$SCRIPT" "$REPO_ROOT/examples/clover.xml" 80 clover
+
+    [ "$status" -eq 0 ]
+    report_json="$(grep "^report-json=" "$OUTPUT_FILE" | cut -d= -f2-)"
+    [ "$(echo "$report_json" | jq -r '.coverageFile')" = "$REPO_ROOT/examples/clover.xml" ]
+    [ "$(echo "$report_json" | jq -r '.coverageType')" = "clover" ]
+    [ "$(echo "$report_json" | jq -r '.coveragePercentage')" = "85" ]
+    [ "$(echo "$report_json" | jq -r '.minimumCoverage')" = "80" ]
+    [ "$(echo "$report_json" | jq -r '.status')" = "pass" ]
+    [ "$(echo "$report_json" | jq -r '.covered')" = "85" ]
+    [ "$(echo "$report_json" | jq -r '.total')" = "100" ]
+}
+
+@test "reports fail status in report-json when coverage is below the minimum" {
+    export GITHUB_OUTPUT="$OUTPUT_FILE"
+
+    run "$SCRIPT" "$REPO_ROOT/examples/clover.xml" 90 clover
+
+    [ "$status" -eq 1 ]
+    report_json="$(grep "^report-json=" "$OUTPUT_FILE" | cut -d= -f2-)"
+    [ "$(echo "$report_json" | jq -r '.status')" = "fail" ]
+}
+
+@test "reports null covered/total for cobertura files without line counts" {
+    export GITHUB_OUTPUT="$OUTPUT_FILE"
+
+    run "$SCRIPT" "$REPO_ROOT/examples/cobertura.xml" 80 cobertura
+
+    [ "$status" -eq 0 ]
+    report_json="$(grep "^report-json=" "$OUTPUT_FILE" | cut -d= -f2-)"
+    [ "$(echo "$report_json" | jq -r '.covered')" = "null" ]
+    [ "$(echo "$report_json" | jq -r '.total')" = "null" ]
+}
+
+@test "writes a JSON report file when json-report-file is provided" {
+    export GITHUB_OUTPUT="$OUTPUT_FILE"
+    report_file="$BATS_TEST_TMPDIR/coverage-report.json"
+
+    run "$SCRIPT" "$REPO_ROOT/examples/clover.xml" 80 clover . "$report_file"
+
+    [ "$status" -eq 0 ]
+    [ -f "$report_file" ]
+    [ "$(jq -r '.coveragePercentage' "$report_file")" = "85" ]
+    [ "$(jq -r '.status' "$report_file")" = "pass" ]
+    grep -Fx "report-file=${report_file}" "$OUTPUT_FILE"
+}
+
+@test "resolves a relative json-report-file against the workspace root, creating missing directories" {
+    export GITHUB_OUTPUT="$OUTPUT_FILE"
+    mkdir -p "$BATS_TEST_TMPDIR/project/coverage"
+    cp "$REPO_ROOT/examples/clover.xml" "$BATS_TEST_TMPDIR/project/coverage/clover.xml"
+
+    run "$SCRIPT" "coverage/clover.xml" 80 clover "$BATS_TEST_TMPDIR/project" "reports/coverage-report.json"
+
+    [ "$status" -eq 0 ]
+    expected_file="$BATS_TEST_TMPDIR/project/reports/coverage-report.json"
+    [ -f "$expected_file" ]
+    [ "$(jq -r '.status' "$expected_file")" = "pass" ]
+    grep -Fx "report-file=${expected_file}" "$OUTPUT_FILE"
+}
+
+@test "does not fail the script when building the JSON report fails" {
+    setup_failing_jq
+    export GITHUB_OUTPUT="$OUTPUT_FILE"
+    unset STATUS_TOKEN
+
+    run "$SCRIPT" "$REPO_ROOT/examples/clover.xml" 80 clover
+
+    [ "$status" -eq 0 ]
+    assert_output_contains "::warning::failed to build coverage JSON report"
+    assert_output_contains "Coverage validation passed!"
+    ! grep -q "^report-json=" "$OUTPUT_FILE"
+}
+
+@test "publishes both a commit status and a report file when both are configured" {
+    setup_fake_curl 0
+    export GITHUB_OUTPUT="$OUTPUT_FILE"
+    export STATUS_TOKEN="test-token"
+    report_file="$BATS_TEST_TMPDIR/coverage-report.json"
+
+    run "$SCRIPT" "$REPO_ROOT/examples/clover.xml" 80 clover . "$report_file"
+
+    [ "$status" -eq 0 ]
+    [ -f "$report_file" ]
+    [ -s "$CURL_LOG" ]
+    grep -q '"state":"success"' "$CURL_LOG"
+    grep -Fx "report-file=${report_file}" "$OUTPUT_FILE"
+}

--- a/validate-coverage.sh
+++ b/validate-coverage.sh
@@ -208,11 +208,53 @@ if [ -n "$GITHUB_OUTPUT" ]; then
     echo "coverage-percentage=${COVERAGE}" >> "$GITHUB_OUTPUT"
 fi
 
+# Publish a commit status with the coverage result, if a token was provided.
+# This is entirely opt-in: with no STATUS_TOKEN, this is a no-op so existing
+# callers see zero behavior change.
+publish_commit_status() {
+    local state="$1"
+    local description="$2"
+
+    if [ -z "${STATUS_TOKEN:-}" ]; then
+        return 0
+    fi
+
+    if [ "${#description}" -gt 140 ]; then
+        description="${description:0:140}"
+    fi
+
+    local context="${STATUS_CONTEXT:-coverage/validate-coverage}"
+    local target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+    local api_url="${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}"
+
+    local body
+    body=$(jq -n -c \
+        --arg state "$state" \
+        --arg context "$context" \
+        --arg description "$description" \
+        --arg target_url "$target_url" \
+        '{state: $state, context: $context, description: $description, target_url: $target_url}')
+
+    # A failed status POST must never fail an otherwise-successful validation run.
+    if ! curl --silent --show-error --fail \
+        --request POST \
+        --header "Authorization: Bearer ${STATUS_TOKEN}" \
+        --header "Accept: application/vnd.github+json" \
+        --header "X-GitHub-Api-Version: 2022-11-28" \
+        --header "Content-Type: application/json" \
+        --data "$body" \
+        --output /dev/null \
+        "$api_url"; then
+        echo "::warning::failed to publish coverage commit status"
+    fi
+}
+
 # Compare with minimum
 if [ "$COVERAGE" -lt "$MINIMUM_COVERAGE" ]; then
     if [ -n "$GITHUB_OUTPUT" ]; then
         echo "status=fail" >> "$GITHUB_OUTPUT"
     fi
+    publish_commit_status "failure" "Coverage: ${COVERAGE}% (min ${MINIMUM_COVERAGE}%)"
     error "Coverage validation failed!"
     error "Actual coverage (${COVERAGE}%) is below minimum required (${MINIMUM_COVERAGE}%)"
     exit 1
@@ -220,6 +262,7 @@ else
     if [ -n "$GITHUB_OUTPUT" ]; then
         echo "status=pass" >> "$GITHUB_OUTPUT"
     fi
+    publish_commit_status "success" "Coverage: ${COVERAGE}% (min ${MINIMUM_COVERAGE}%)"
     success "Coverage validation passed!"
     success "Actual coverage (${COVERAGE}%) meets minimum requirement (${MINIMUM_COVERAGE}%)"
 fi

--- a/validate-coverage.sh
+++ b/validate-coverage.sh
@@ -249,14 +249,22 @@ else
     echo "::warning::jq is not installed; skipping JSON report generation"
 fi
 
-# Write the JSON report to file, if requested. Resolve to an absolute path
-# since downstream steps (e.g. actions/upload-artifact) resolve relative
-# paths against the workspace root, not this script's working directory.
-REPORT_FILE_ABS=""
+# Write the JSON report to file, if requested. This runs inside the action's
+# Docker container, so an absolute path here (e.g. /github/workspace/...) is a
+# container-local path that later, non-container workflow steps (like
+# actions/upload-artifact) can't use. Emit a path relative to $GITHUB_WORKSPACE
+# instead, when the report lives under it, so it's directly usable by
+# subsequent steps; fall back to the absolute path otherwise.
+REPORT_FILE_OUTPUT=""
 if [ -n "$JSON_REPORT_FILE" ] && [ -n "$REPORT_JSON" ]; then
     if mkdir -p "$(dirname "$JSON_REPORT_FILE")" && echo "$REPORT_JSON" | jq '.' > "$JSON_REPORT_FILE"; then
-        REPORT_FILE_ABS="$(cd "$(dirname "$JSON_REPORT_FILE")" && pwd)/$(basename "$JSON_REPORT_FILE")"
-        log "Wrote JSON report to: $REPORT_FILE_ABS"
+        report_file_abs="$(cd "$(dirname "$JSON_REPORT_FILE")" && pwd)/$(basename "$JSON_REPORT_FILE")"
+        if [ -n "${GITHUB_WORKSPACE:-}" ] && [[ "$report_file_abs" == "$GITHUB_WORKSPACE"/* ]]; then
+            REPORT_FILE_OUTPUT="${report_file_abs#"$GITHUB_WORKSPACE"/}"
+        else
+            REPORT_FILE_OUTPUT="$report_file_abs"
+        fi
+        log "Wrote JSON report to: $report_file_abs"
     else
         echo "::warning::failed to write JSON report to: $JSON_REPORT_FILE"
     fi
@@ -270,8 +278,8 @@ if [ -n "$GITHUB_OUTPUT" ]; then
         if [ -n "$REPORT_JSON" ]; then
             echo "report-json=${REPORT_JSON}"
         fi
-        if [ -n "$REPORT_FILE_ABS" ]; then
-            echo "report-file=${REPORT_FILE_ABS}"
+        if [ -n "$REPORT_FILE_OUTPUT" ]; then
+            echo "report-file=${REPORT_FILE_OUTPUT}"
         fi
     } >> "$GITHUB_OUTPUT"
 fi

--- a/validate-coverage.sh
+++ b/validate-coverage.sh
@@ -6,6 +6,7 @@ COVERAGE_FILE="$1"
 MINIMUM_COVERAGE="$2"
 COVERAGE_TYPE="${3:-clover}"
 WORKING_DIRECTORY="${4:-.}"
+JSON_REPORT_FILE="${5:-}"
 
 # Colors for output
 RED='\033[0;31m'
@@ -33,18 +34,20 @@ error() {
 
 # Function to show usage
 show_usage() {
-    echo "Usage: $0 <coverage-file> <minimum-percentage> [coverage-type] [working-directory]"
+    echo "Usage: $0 <coverage-file> <minimum-percentage> [coverage-type] [working-directory] [json-report-file]"
     echo ""
     echo "Parameters:"
     echo "  coverage-file       Path to the coverage file"
     echo "  minimum-percentage  Minimum coverage percentage (0-100)"
     echo "  coverage-type       Type of coverage file (clover, cobertura, jacoco) - defaults to 'clover'"
     echo "  working-directory   Working directory - defaults to current directory"
+    echo "  json-report-file    Path to write a machine-readable JSON report - optional"
     echo ""
     echo "Examples:"
     echo "  $0 coverage/clover.xml 80"
     echo "  $0 coverage/cobertura.xml 75 cobertura"
     echo "  $0 coverage/jacoco.xml 90 jacoco /path/to/project"
+    echo "  $0 coverage/clover.xml 80 clover . coverage-report.json"
 }
 
 detect_coverage_type() {
@@ -159,6 +162,10 @@ case "$COVERAGE_TYPE" in
         
         # Convert decimal to percentage
         COVERAGE=$(echo "$LINE_RATE * 100" | bc | cut -d. -f1)
+
+        # Extract covered/total line counts if present, for the JSON report
+        COVERED=$(xmllint --xpath "string(/coverage/@lines-covered)" "$COVERAGE_FILE" 2>/dev/null || echo "")
+        TOTAL=$(xmllint --xpath "string(/coverage/@lines-valid)" "$COVERAGE_FILE" 2>/dev/null || echo "")
         ;;
         
     "jacoco")
@@ -203,9 +210,70 @@ fi
 
 log "Actual coverage: ${COVERAGE}%"
 
+# Determine pass/fail status up front so the report and outputs below agree
+# with the exit code decided later.
+if [ "$COVERAGE" -lt "$MINIMUM_COVERAGE" ]; then
+    STATUS="fail"
+else
+    STATUS="pass"
+fi
+
+# Build a machine-readable JSON report, for orgs whose dashboards consume a
+# workflow artifact rather than a commit status. Report generation is
+# best-effort: a broken jq must never fail an otherwise-successful run.
+REPORT_JSON=""
+if command -v jq &> /dev/null; then
+    if ! REPORT_JSON=$(jq -n -c \
+        --arg coverageFile "$COVERAGE_FILE" \
+        --arg coverageType "$COVERAGE_TYPE" \
+        --argjson coveragePercentage "$COVERAGE" \
+        --argjson minimumCoverage "$MINIMUM_COVERAGE" \
+        --arg status "$STATUS" \
+        --arg covered "${COVERED:-}" \
+        --arg total "${TOTAL:-}" \
+        --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        '{
+            coverageFile: $coverageFile,
+            coverageType: $coverageType,
+            coveragePercentage: $coveragePercentage,
+            minimumCoverage: $minimumCoverage,
+            status: $status,
+            covered: (if $covered == "" then null else ($covered | tonumber) end),
+            total: (if $total == "" then null else ($total | tonumber) end),
+            timestamp: $timestamp
+        }'); then
+        echo "::warning::failed to build coverage JSON report"
+        REPORT_JSON=""
+    fi
+else
+    echo "::warning::jq is not installed; skipping JSON report generation"
+fi
+
+# Write the JSON report to file, if requested. Resolve to an absolute path
+# since downstream steps (e.g. actions/upload-artifact) resolve relative
+# paths against the workspace root, not this script's working directory.
+REPORT_FILE_ABS=""
+if [ -n "$JSON_REPORT_FILE" ] && [ -n "$REPORT_JSON" ]; then
+    if mkdir -p "$(dirname "$JSON_REPORT_FILE")" && echo "$REPORT_JSON" | jq '.' > "$JSON_REPORT_FILE"; then
+        REPORT_FILE_ABS="$(cd "$(dirname "$JSON_REPORT_FILE")" && pwd)/$(basename "$JSON_REPORT_FILE")"
+        log "Wrote JSON report to: $REPORT_FILE_ABS"
+    else
+        echo "::warning::failed to write JSON report to: $JSON_REPORT_FILE"
+    fi
+fi
+
 # Set outputs for GitHub Actions (if running in GitHub Actions)
 if [ -n "$GITHUB_OUTPUT" ]; then
-    echo "coverage-percentage=${COVERAGE}" >> "$GITHUB_OUTPUT"
+    {
+        echo "coverage-percentage=${COVERAGE}"
+        echo "status=${STATUS}"
+        if [ -n "$REPORT_JSON" ]; then
+            echo "report-json=${REPORT_JSON}"
+        fi
+        if [ -n "$REPORT_FILE_ABS" ]; then
+            echo "report-file=${REPORT_FILE_ABS}"
+        fi
+    } >> "$GITHUB_OUTPUT"
 fi
 
 # Publish a commit status with the coverage result, if a token was provided.
@@ -254,19 +322,13 @@ publish_commit_status() {
     fi
 }
 
-# Compare with minimum
-if [ "$COVERAGE" -lt "$MINIMUM_COVERAGE" ]; then
-    if [ -n "$GITHUB_OUTPUT" ]; then
-        echo "status=fail" >> "$GITHUB_OUTPUT"
-    fi
+# Report the final result and exit accordingly
+if [ "$STATUS" = "fail" ]; then
     publish_commit_status "failure" "Coverage: ${COVERAGE}% (min ${MINIMUM_COVERAGE}%)"
     error "Coverage validation failed!"
     error "Actual coverage (${COVERAGE}%) is below minimum required (${MINIMUM_COVERAGE}%)"
     exit 1
 else
-    if [ -n "$GITHUB_OUTPUT" ]; then
-        echo "status=pass" >> "$GITHUB_OUTPUT"
-    fi
     publish_commit_status "success" "Coverage: ${COVERAGE}% (min ${MINIMUM_COVERAGE}%)"
     success "Coverage validation passed!"
     success "Actual coverage (${COVERAGE}%) meets minimum requirement (${MINIMUM_COVERAGE}%)"

--- a/validate-coverage.sh
+++ b/validate-coverage.sh
@@ -227,13 +227,18 @@ publish_commit_status() {
     local target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
     local api_url="${GITHUB_API_URL:-https://api.github.com}/repos/${GITHUB_REPOSITORY}/statuses/${GITHUB_SHA}"
 
+    # Building the payload must never fail the run either, so guard the jq
+    # call itself rather than letting `set -e` abort on a non-zero exit.
     local body
-    body=$(jq -n -c \
+    if ! body=$(jq -n -c \
         --arg state "$state" \
         --arg context "$context" \
         --arg description "$description" \
         --arg target_url "$target_url" \
-        '{state: $state, context: $context, description: $description, target_url: $target_url}')
+        '{state: $state, context: $context, description: $description, target_url: $target_url}'); then
+        echo "::warning::failed to build coverage commit status payload"
+        return 0
+    fi
 
     # A failed status POST must never fail an otherwise-successful validation run.
     if ! curl --silent --show-error --fail \


### PR DESCRIPTION
## Summary

Adds two independent, **opt-in** ways to report coverage results out of the action — neither changes default behavior for existing callers.

### 1. Commit status (feeds the `vln-devsecops/operations` org dashboard)

- **`action.yml`**: two new optional inputs, `github-token` and `status-context` (default `coverage/validate-coverage`), wired into the container via `runs.env` (`STATUS_TOKEN` / `STATUS_CONTEXT`). The existing positional `args` list is untouched.
- **`validate-coverage.sh`**: after computing the pass/fail result, publishes a commit status (`state: success` or `state: failure` — never `pending`/`error`) via `curl` + `jq`, but **only if `STATUS_TOKEN` is set**. With it unset (the default), zero behavior change. A failed status POST or a broken `jq` logs a `::warning::` and never fails an otherwise-successful validation run.
- Feeds the `vln-devsecops/operations` dashboard (PR #26, merged to `dev`), which reads each monitored repo's combined commit status on its default branch.

### 2. Portable JSON report (any org, any dashboard)

- **`action.yml`**: new optional `json-report-file` input (5th positional arg, consistent with the other coverage-file/type/working-directory args) and two new outputs, `report-json` (always produced) and `report-file` (set when `json-report-file` is provided and the write succeeds).
- **`validate-coverage.sh`**: always builds a compact JSON summary (`coverageFile`, `coverageType`, `coveragePercentage`, `minimumCoverage`, `status`, `covered`, `total`, `timestamp`); optionally writes it to an absolute path on disk for upload via `actions/upload-artifact`. Report generation is best-effort — a missing/broken `jq` or a failed write logs a `::warning::` and never fails the run.
- This exists because the commit-status mechanism above is specific to consumers that read GitHub's commit-status API (like the `vln-devsecops/operations` dashboard); orgs outside `vln-devsecops` — or any dashboard that consumes workflow artifacts instead — can use this without needing a token or touching commit statuses at all.

Both features are independent: use either, both, or neither.

### Docs & tests

- README documents both inputs/outputs, with a "Reporting to dashboards" section split into the two mechanisms and a portable usage example (`json-report-file` + `actions/upload-artifact`).
- BATS suite: 21 tests total (9 original + 12 new), covering token-unset/set for commit status, jq/curl failure guards for both features, JSON report shape (including the Cobertura null-covered/total case), report-file path resolution (including relative-path + missing-directory creation), and using both features together. `shellcheck validate-coverage.sh` is clean.

No new token permissions needed anywhere — each repo posts its own commit status using its own workflow's `GITHUB_TOKEN` (default `statuses: write`), and the JSON report needs no token at all.

Versioning: additive/non-breaking, so `release-please` will pick this up as a `feat:` commit and cut a new minor version automatically; no manual tagging needed.

## Test plan

- [x] `bats tests/validate-coverage.bats` — all 21 tests pass
- [x] `shellcheck validate-coverage.sh` — clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('action.yml'))"` — valid YAML
- [ ] CI (lint, test_bash, docker build/test) green on this PR
